### PR TITLE
Changed minimum value of rx2.buffer-size to 1

### DIFF
--- a/flowable/src/main/java/io/reactivex/flowable/Flowable.java
+++ b/flowable/src/main/java/io/reactivex/flowable/Flowable.java
@@ -55,7 +55,7 @@ public abstract class Flowable<T> implements Publisher<T> {
     /** The default buffer size. */
     static final int BUFFER_SIZE;
     static {
-        BUFFER_SIZE = Math.max(16, Integer.getInteger("rx2.buffer-size", 128));
+        BUFFER_SIZE = Math.max(1, Integer.getInteger("rx2.buffer-size", 128));
     }
 
     /**


### PR DESCRIPTION
Before the minimum value you could set with the system variable `rx2.buffer-size` was 16. With this commit, that is changed to 1.